### PR TITLE
Run all CI on nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - run: npm install wasm-opt -g
       - uses: actions/checkout@v3
       - name: Install nightly toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1.3.7
         with:
           toolchain: nightly
           target: wasm32-unknown-unknown


### PR DESCRIPTION
Since nightly is needed for contracts we could save the time to download two tool chains and run fmt and clippy on nightly too